### PR TITLE
[sol-add-home-page-object] - adding page object for homepage 

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: npx playwright install
     - name: Run Playwright tests
       run: npm run ui:tests 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers
-      run: npx playwright install
+      run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npm run ui:tests 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests
-      run: npx playwright test
+      run: npm run ui:tests 
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "solirious demo",
   "main": "index.js",
   "scripts": {
-    "test": "run"
+    "ui:tests": "npx playwright test"
   },
   "repository": {
     "type": "git",

--- a/page-objects/homepage.ts
+++ b/page-objects/homepage.ts
@@ -1,0 +1,25 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { testURL } from '../consts'; 
+
+export class HomePage {
+  readonly page: Page;
+  readonly getStartedLink: Locator;
+  readonly gettingStartedHeader: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.getStartedLink = page.getByRole('button', { name: 'Start now' });
+    this.gettingStartedHeader = page.getByRole('heading', { name: 'Calculate holiday entitlement' });
+  }
+
+  async goto() {
+    await this.page.goto(testURL);
+  }
+
+  async pageLoaded() {
+    // Expect a title, header and get started button 
+    await expect(this.page).toHaveTitle(/Calculate holiday entitlement/);
+    await expect(this.getStartedLink).toBeVisible();
+    await expect(this.gettingStartedHeader).toBeVisible();
+  }
+}

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -1,19 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { testURL } from '../consts';
+import { HomePage } from '../page-objects/homepage';
 
-test('page should have title - html loaded', async ({ page }) => {
-  await page.goto(testURL);
+test('page should be loaded with key components', async ({ page }) => {
+  const homepage = new HomePage(page);
 
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Calculate holiday entitlement/);
-});
+  await homepage.goto();
 
-test('key components should be visible', async ({ page }) => {
-  await page.goto(testURL);
-
-  // heading should be displayed 
-  await expect(page.getByRole('heading', { name: 'Calculate holiday entitlement' })).toBeVisible();
-
-  // start now button should be displayed 
-  await expect(page.getByRole('button', { name: 'Start now' })).toBeVisible();
+  await homepage.pageLoaded();
 });


### PR DESCRIPTION
## Changes 

In this PR am adding a page object to represent the homepage and its components. Also have updated the homepage test to use it 

## List of changes 

- adding page object for homepage 
- updating homepage test to use page object 
- updating package json with command to run tests 


## Checklist 

- [ ] Lint checks passing 

- [ ] Unit tests added and passing 