### PR TITLE
[sol-add-cookies-test] - adding tests for cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ You can use the following command to run the tests `npm run ui:tests`
 
 Alternativley you can run tests using the activity sidebar- details here https://playwright.dev/docs/getting-started-vscode#opening-the-testing-sidebar 
 
+## Test output 
+
+When running a set of tests it will generate an html report - `index.html`, which can be found in the `playwright-report` folder 
+
+This allows you to see details of which tests where run, and also filter by status etc. 
+
 ## Tests in deployment 
 
 The tests are also configured to run as part of the deployment process - see `workflows/playright.yml` 
@@ -34,5 +40,7 @@ The tests are also configured to run as part of the deployment process - see `wo
 They are set to run with the following triggers 
 
 - On opening pull request 
-- On pushes to a branch (PR) 
+- On each push to a branch (PR) 
+
+You can find the deployments in this tab https://github.com/marcpodgorney81/solirious-demo/actions 
 

--- a/page-objects/homepage.ts
+++ b/page-objects/homepage.ts
@@ -5,15 +5,32 @@ export class HomePage {
   readonly page: Page;
   readonly getStartedLink: Locator;
   readonly gettingStartedHeader: Locator;
+  readonly cookieBanner: Locator;
+  readonly acceptCookiesButton: Locator;
+  readonly acceptCookiesMessage: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.getStartedLink = page.getByRole('button', { name: 'Start now' });
     this.gettingStartedHeader = page.getByRole('heading', { name: 'Calculate holiday entitlement' });
+    this.cookieBanner = page.getByTestId('global-cookie-message');
+    this.acceptCookiesButton = page.getByRole('button', { name: /Accept/ });
+    this.acceptCookiesMessage = page.getByText(/have accepted/ );
   }
 
   async goto() {
     await this.page.goto(testURL);
+  }
+
+  async hasCookieBanner() {
+    // Expect that cookie banner is displayed 
+    await expect(this.cookieBanner).toBeVisible();
+  }
+
+  async acceptCookies() {
+    // Expect that when clicking to accept confirmation message is displayed 
+    await this.acceptCookiesButton.click();
+    await expect(this.acceptCookiesMessage).toBeVisible();
   }
 
   async pageLoaded() {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    testIdAttribute: 'id', //allows finding elements by id 
   },
 
   /* Configure projects for major browsers */

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -6,6 +6,19 @@ test('page should be loaded with key components', async ({ page }) => {
   const homepage = new HomePage(page);
 
   await homepage.goto();
-
   await homepage.pageLoaded();
+});
+
+test('cookie banner should be displayed', async ({ page }) => {
+  const homepage = new HomePage(page);
+
+  await homepage.goto();
+  await homepage.hasCookieBanner();
+});
+
+test('accpeting cookies should show confirmation message', async ({ page }) => {
+  const homepage = new HomePage(page);
+
+  await homepage.goto();
+  await homepage.acceptCookies();
 });


### PR DESCRIPTION
## Changes 

In this PR am adding tests for the cookie banner 

## List of changes 

- adding tests for cookie banner 
- updating playwright config to use `id` with `getByTestId` 


## Checklist 

- [ ] Lint checks passing 

- [ ] Unit tests added and passing 